### PR TITLE
fix: NPE when no headers in the request

### DIFF
--- a/src/main/java/io/gravitee/tracer/opentelemetry/instrumenter/HttpInstrumenterVertxTracer.java
+++ b/src/main/java/io/gravitee/tracer/opentelemetry/instrumenter/HttpInstrumenterVertxTracer.java
@@ -530,7 +530,11 @@ public class HttpInstrumenterVertxTracer implements InstrumenterVertxTracer<Http
                     return result;
                 }
             };
-            return headers.addAll(httpRequest.headers());
+            MultiMap requestHeaders = httpRequest.headers();
+            if (requestHeaders != null) {
+                return headers.addAll(requestHeaders);
+            }
+            return headers;
         }
 
         @Override


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6659

**Description**


when setting JWKS_URL in the JWT policy otel throws NPE because no headers are set [link](https://github.com/gravitee-io/gravitee-policy-jwt/blob/1fd0dea95c6521e2bb4223829367b1a1ed9bd36c/src/main/java/io/gravitee/policy/jwt/jwk/source/VertxResourceRetriever.java#L64)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.1-APIM-6443-fix-npe-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/tracer/gravitee-tracer-opentelemetry/1.0.1-APIM-6443-fix-npe-SNAPSHOT/gravitee-tracer-opentelemetry-1.0.1-APIM-6443-fix-npe-SNAPSHOT.zip)
  <!-- Version placeholder end -->
